### PR TITLE
Add missing apostrophe in core-concepts.mdx

### DIFF
--- a/docs/core-concepts.mdx
+++ b/docs/core-concepts.mdx
@@ -18,7 +18,7 @@ export const compose = (...funcs: Func[]) => {
 }
 ```
 
-Thats it... thats the function.
+That's it... that's the function.
 
 ### Semi-Functional
 


### PR DESCRIPTION
## Description

Add missing apostrophe in core-concepts.mdx in word "that's".

