### PR TITLE
Fix title function doesn't support incoming strings containing a section of uppercase letters

### DIFF
--- a/src/string.ts
+++ b/src/string.ts
@@ -97,15 +97,22 @@ export const pascal = (str: string): string => {
  * title('va_va_boom') -> 'Va Va Boom'
  * title('root-hook') -> 'Root Hook'
  * title('queryItems') -> 'Query Items'
+ * title('ABC') -> 'Abc'
+ * title('ABC_content') -> 'Abc Content'
  */
 export const title = (str: string | null | undefined): string => {
-  if (!str) return ''
+  if (!str) return '';
+
   return str
-    .split(/(?=[A-Z])|[\.\-\s_]/)
-    .map(s => s.trim())
-    .filter(s => !!s)
-    .map(s => capitalize(s.toLowerCase()))
-    .join(' ')
+    .split(/(?=[A-Z][a-z])|[\.\-\s_]/)
+    .map(s => {
+      if (s === s.toUpperCase()) {
+        // If the entire string segment is uppercase, capitalize it properly
+        return capitalize(s.toLowerCase());
+      }
+      return capitalize(s);
+    })
+    .join(' ');
 }
 
 /**

--- a/src/tests/string.test.ts
+++ b/src/tests/string.test.ts
@@ -174,6 +174,8 @@ describe('string module', () => {
         _.title('queryAllItems-in_Database'),
         'Query All Items In Database'
       )
+      assert.equal(_.title('ABC'), 'Abc')
+      assert.equal(_.title('ABC_content'), 'Abc Content')
     })
     test('returns empty string for bad input', () => {
       assert.equal(_.title(null), '')


### PR DESCRIPTION
## Description

title function doesn't support incoming strings containing a section of uppercase letters
<img width="1056" alt="image" src="https://github.com/user-attachments/assets/a9ccbefb-a758-48dc-a5c1-f272ee6ee08f">


## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves
`Resolves #439`
