### PR TITLE
fix: fix the boil function example code

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -82,7 +82,7 @@ export function zipToObject<K extends string | number | symbol, V>(
  * and comparing with the second. Keep the one you want then
  * compare that to the next item in the list with the same
  *
- * Ex. const greatest = () => boil(numbers, (a, b) => a > b)
+ * Ex. const greatest = () => boil(numbers, (a, b) => a > b ? a : b)
  */
 export const boil = <T>(
   array: readonly T[],


### PR DESCRIPTION
## Description

```ts
const greatest = () => boil(numbers, (a, b) => a > b)
```
The greatest  is boolean not a number.

And it should be bellow code

```ts
const greatest = () => boil(numbers, (a, b) => a > b ? a : b)
```

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

If the PR resolves an open issue tag it here. For example, `Resolves #34`
