### PR TITLE
docs: improve isEqual examples

### DIFF
--- a/docs/typed/is-equal.mdx
+++ b/docs/typed/is-equal.mdx
@@ -13,6 +13,7 @@ import { isEqual } from 'radash'
 
 isEqual(null, null) // => true
 isEqual([], [])     // => true
+isEqual({ hello: 'world' }, { hello: 'world' }) // => true
 
 isEqual('hello', 'world') // => false
 isEqual(22, 'abc')        // => false


### PR DESCRIPTION
## Description

Currently, the isEqual documentation does not include an example demonstrating its use with objects, despite the fact that it supports them. I’ve provided a simple example to illustrate this functionality and to emphasize that object comparisons are indeed supported.

## Checklist

- [n/a] Changes are covered by tests if behavior has been changed or added
- [n/a] Tests have 100% coverage
- [n/a] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [n/a ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [n/a] If code changes were made, the documentation (in the `/docs` directory) has been updated

## Resolves

If the PR resolves an open issue tag it here. For example, `Resolves #34`
