### PR TITLE
fix: make sure that the input parameters are definitely of array type

### DIFF
--- a/src/array.ts
+++ b/src/array.ts
@@ -88,7 +88,7 @@ export const boil = <T>(
   array: readonly T[],
   compareFunc: (a: T, b: T) => T
 ) => {
-  if (!array || (array.length ?? 0) === 0) return null
+  if (!array || !Array.isArray(array) || (array.length ?? 0) === 0) return null
   return array.reduce(compareFunc)
 }
 

--- a/src/tests/array.test.ts
+++ b/src/tests/array.test.ts
@@ -43,7 +43,7 @@ describe('array module', () => {
       assert.isNull(result)
     })
     test('does not fail when provided array is funky shaped', () => {
-      const result = _.boil({} as any, () => true)
+      const result = _.boil({ length: 10 } as any, () => true)
       assert.isNull(result)
     })
   })


### PR DESCRIPTION
## Description

I found that the current boil function will report an error if an object with a length field is passed in. This has now been fixed.

## Checklist

- [ ] Changes are covered by tests if behavior has been changed or added
- [ ] Tests have 100% coverage
- [ ] If code changes were made, the version in `package.json` has been bumped (matching semver)
- [ ] If code changes were made, the `yarn build` command has been run and to update the `cdn` directory
- [ ] If code changes were made, the documentation (in the `/docs` directory) has been updated

